### PR TITLE
Move edit button to info window

### DIFF
--- a/src/ClueInfo.js
+++ b/src/ClueInfo.js
@@ -1,19 +1,29 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
+import { Button } from 'react-bootstrap';
+import { InfoWindow } from 'google-maps-react';
 
 export default class ClueInfo extends React.Component {
-  render() {
-    const clue = this.props.clue;
-    if (!clue) {
-      return <div/>;
+  constructor(props) {
+    super(props);
+    this.infoWindowRef = React.createRef();
+    this.contentElement = document.createElement(`div`);
+  }
+
+  // Annoying workaround since google.InfoWindow doesn't allow
+  // event callbacks from within the component
+  // https://stackoverflow.com/questions/53615413/how-to-add-a-button-in-infowindow-with-google-maps-react
+  componentDidUpdate(prevProps) {
+    if (this.props.children !== prevProps.children) {
+      ReactDOM.render(
+        this.props.children,
+        this.contentElement
+      );
+      this.infoWindowRef.current.infowindow.setContent(this.contentElement);
     }
+  }
 
-    let status = clue.completed ? "Completed" : "Not completed";
-
-    return (
-      <div>
-        <h4>{clue.title} ({clue.clueId})</h4>
-        <h5>{status}</h5>
-      </div>
-    );
+  render() {
+    return <InfoWindow ref={this.infoWindowRef} {...this.props} />;
   }
 }

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -86,12 +86,20 @@ class Dashboard extends Component {
             {this.renderClues()}
             {this.renderHunters()}
 
-            <InfoWindow
+            <ClueInfo
               onClose={this.removeFocus}
               marker={this.state.selectedClueMarker}
               visible={this.state.selectedClue !== null}>
-              <ClueInfo clue={this.state.selectedClue} />
-            </InfoWindow>
+              { (this.state.selectedClue) ?
+                <div>
+                <h4>{this.state.selectedClue.title} ({this.state.selectedClue.clueId})</h4>
+                <h5>{this.state.selectedClue.completed ? "Complete" : "Incomplete"}</h5>
+                </div>
+                  :
+                  undefined
+              }
+              <Button onClick={this.toggleShowingClueEditWindow}>Edit</Button>
+            </ClueInfo>
             <InfoWindow
               onClose={this.removeFocus}
               marker={this.state.selectedHunterMarker}
@@ -118,13 +126,6 @@ class Dashboard extends Component {
             </ToggleButton>
           </ToggleButtonGroup>
         </div>
-
-        <Button className="top-right-absolute"
-                bsStyle="primary"
-                disabled={!this.state.selectedClue} // Only allow editing when clue selected
-                onClick={this.toggleShowingClueEditWindow}>
-          Edit Clue
-        </Button>
 
         <Modal show={this.state.showingClueEditWindow}
                onHide={this.toggleShowingClueEditWindow}>

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -90,14 +90,7 @@ class Dashboard extends Component {
               onClose={this.removeFocus}
               marker={this.state.selectedClueMarker}
               visible={this.state.selectedClue !== null}>
-              { (this.state.selectedClue) ?
-                <div>
-                <h4>{this.state.selectedClue.title} ({this.state.selectedClue.clueId})</h4>
-                <h5>{this.state.selectedClue.completed ? "Complete" : "Incomplete"}</h5>
-                </div>
-                  :
-                  undefined
-              }
+              { this.state.selectedClue && this.renderClueInfo() }
               <Button onClick={this.toggleShowingClueEditWindow}>Edit</Button>
             </ClueInfo>
             <InfoWindow
@@ -200,6 +193,15 @@ class Dashboard extends Component {
         />
       );
     });
+  }
+
+  renderClueInfo() {
+    return (
+      <div>
+        <h4>{this.state.selectedClue.title} ({this.state.selectedClue.clueId})</h4>
+        <h5>{this.state.selectedClue.completed ? "Complete" : "Incomplete"}</h5>
+      </div>
+    );
   }
 
   // Select the given clue/marker to populate the info window


### PR DESCRIPTION
Didn't do this from the beginning because google maps info window component blocks event callbacks but found a workaround for it. Makes a lot more sense to put the edit button in the info window.