### PR TITLE
set boolean value of checkbox directly

### DIFF
--- a/src/ClueUploadForm.js
+++ b/src/ClueUploadForm.js
@@ -63,7 +63,8 @@ export default class ClueUploadForm extends React.Component {
             <Form.Label>Crawl?</Form.Label>
             <Form.Check
               type="checkbox"
-              onChange={() => this.setState({inCrawl: !this.state.inCrawl})}
+              checked={this.state.inCrawl}
+              onChange={(e) => this.setState({inCrawl: e.target.checked})}
             />
           </Form.Group>
 


### PR DESCRIPTION
Checkbox wasn't getting reset at the submission of a clue. Though not necessarily a bug, it is expected that it would reset like everything else.