### PR TITLE
add clue num to updated fields

### DIFF
--- a/src/ClueEditForm.js
+++ b/src/ClueEditForm.js
@@ -125,6 +125,7 @@ export default class ClueEditForm extends React.Component {
 
     let updatedClueFields = {
       clueListId: this.state.clueListId,
+      clueNum: this.state.clueNum,
       title: this.state.title,
       inCrawl: this.state.inCrawl,
       completed: this.state.completedStatus,


### PR DESCRIPTION
The clue number wasn't added to the updated fields that were sent to firebase.

Resolves #22  